### PR TITLE
Fix window display on multi-monitor setup

### DIFF
--- a/TOMB4/specific/winmain.cpp
+++ b/TOMB4/specific/winmain.cpp
@@ -389,7 +389,7 @@ LRESULT CALLBACK WinMainWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPar
 
 	case WM_MOVE:
 		Log(6, "WM_MOVE");
-		DXMove(lParam & 0xFFFF, short((lParam >> 16) & 0xFFFF));
+		DXMove((short)(lParam & 0xFFFF), (short)((lParam >> 16) & 0xFFFF));
 		break;
 
 	case WM_ACTIVATE:


### PR DESCRIPTION
Fixes a wrapping error when moving the game's window to a second monitor which causes it to be frozen. Makes it consistent with behaviour of the original binary.