### PR TITLE
Added Mipmap functionality.

### DIFF
--- a/TOMB4/specific/file.cpp
+++ b/TOMB4/specific/file.cpp
@@ -53,6 +53,15 @@ static char* FileData;
 static char* CompressedData;
 static long num_items;
 
+#ifndef MIPMAPPING
+#define MIPMAPCOUNT_ROOM 0
+#define MIPMAPCOUNT_OBJECT 0
+#else
+// Only two mip maps, anything beyond causes too many bleeding issues
+#define MIPMAPCOUNT_ROOM 2
+#define MIPMAPCOUNT_OBJECT 1
+#endif
+
 unsigned int __stdcall LoadLevel(void* name)
 {
 	OBJECT_INFO* obj;
@@ -418,7 +427,7 @@ bool LoadTextures(long RTPages, long OTPages, long BTPages)
 		Textures = (TEXTURE*)AddStruct(Textures, nTextures, sizeof(TEXTURE));
 		nTex = nTextures;
 		nTextures++;
-		tSurf = CreateTexturePage(App.TextureSize, App.TextureSize, 0, (long*)(TextureData + (i * skip * 0x10000)), 0, format);
+		tSurf = CreateTexturePage(App.TextureSize, App.TextureSize, MIPMAPCOUNT_ROOM, (long*)(TextureData + (i * skip * 0x10000)), 0, format);
 		DXAttempt(tSurf->QueryInterface(TEXGUID, (LPVOID*)&pTex));
 		Textures[nTex].tex = pTex;
 		Textures[nTex].surface = tSurf;
@@ -442,7 +451,7 @@ bool LoadTextures(long RTPages, long OTPages, long BTPages)
 		Textures = (TEXTURE*)AddStruct(Textures, nTextures, sizeof(TEXTURE));
 		nTex = nTextures;
 		nTextures++;
-		tSurf = CreateTexturePage(App.TextureSize, App.TextureSize, 0, (long*)(TextureData + (i * skip * 0x10000)), 0, format);
+		tSurf = CreateTexturePage(App.TextureSize, App.TextureSize, MIPMAPCOUNT_OBJECT, (long*)(TextureData + (i * skip * 0x10000)), 0, format);
 		DXAttempt(tSurf->QueryInterface(TEXGUID, (LPVOID*)&pTex));
 		Textures[nTex].tex = pTex;
 		Textures[nTex].surface = tSurf;
@@ -467,13 +476,13 @@ bool LoadTextures(long RTPages, long OTPages, long BTPages)
 		for (int i = 0; i < BTPages; i++)
 		{
 			if (i < (BTPages >> 1))
-				tSurf = CreateTexturePage(App.TextureSize, App.TextureSize, 0, (long*)(TextureData + (i * skip * 0x10000)), 0, format);
+				tSurf = CreateTexturePage(App.TextureSize, App.TextureSize, MIPMAPCOUNT_ROOM, (long*)(TextureData + (i * skip * 0x10000)), 0, format);
 			else
 			{
 				if (!App.BumpMapping)
 					break;
 
-				tSurf = CreateTexturePage(App.BumpMapSize, App.BumpMapSize, 0, (long*)(TextureData + (i * skip * 0x10000)), 0, format);
+				tSurf = CreateTexturePage(App.BumpMapSize, App.BumpMapSize, MIPMAPCOUNT_ROOM, (long*)(TextureData + (i * skip * 0x10000)), 0, format);
 			}
 
 			Textures = (TEXTURE*)AddStruct(Textures, nTextures, sizeof(TEXTURE));
@@ -591,7 +600,7 @@ bool LoadTextures(long RTPages, long OTPages, long BTPages)
 	Textures = (TEXTURE*)AddStruct(Textures, nTextures, sizeof(TEXTURE));
 	nTex = nTextures;
 	nTextures++;
-	tSurf = CreateTexturePage(256, 256, 0, (long*)TextureData, 0, 0);
+	tSurf = CreateTexturePage(256, 256, MIPMAPCOUNT_ROOM, (long*)TextureData, 0, 0);
 	DXAttempt(tSurf->QueryInterface(TEXGUID, (LPVOID*)&pTex));
 	Textures[nTex].tex = pTex;
 	Textures[nTex].surface = tSurf;

--- a/TOMB4/specific/function_table.cpp
+++ b/TOMB4/specific/function_table.cpp
@@ -43,11 +43,17 @@ void HWInitialise()
 	{
 		App.dx.lpD3DDevice->SetTextureStageState(0, D3DTSS_MAGFILTER, D3DTFG_LINEAR);
 		App.dx.lpD3DDevice->SetTextureStageState(0, D3DTSS_MINFILTER, D3DTFN_LINEAR);
+#ifdef MIPMAPPING
+		App.dx.lpD3DDevice->SetTextureStageState(0, D3DTSS_MIPFILTER, D3DTFP_LINEAR);
+#endif
 	}
 	else
 	{
 		App.dx.lpD3DDevice->SetTextureStageState(0, D3DTSS_MAGFILTER, D3DTFG_POINT);
 		App.dx.lpD3DDevice->SetTextureStageState(0, D3DTSS_MINFILTER, D3DTFN_POINT);
+#ifdef MIPMAPPING
+		App.dx.lpD3DDevice->SetTextureStageState(0, D3DTSS_MIPFILTER, D3DTFP_POINT);
+#endif
 	}
 
 	App.dx.lpD3DDevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_MODULATE);

--- a/tomb4.vcxproj
+++ b/tomb4.vcxproj
@@ -90,7 +90,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;GENERAL_FIXES;CUTSEQ_SKIPPER;_CRT_SECURE_NO_WARNINGS;FOOTPRINTS;SMOOTH_SHADOWS;DISCORD_RPC;IMPROVED_BARS;ENEMY_BARS;TR2MAIN_WIDESCREEN;NO_CD;AMMO_COUNTER;_DEBUG;TOMB4_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;GENERAL_FIXES;CUTSEQ_SKIPPER;_CRT_SECURE_NO_WARNINGS;FOOTPRINTS;SMOOTH_SHADOWS;DISCORD_RPC;IMPROVED_BARS;ENEMY_BARS;TR2MAIN_WIDESCREEN;NO_CD;AMMO_COUNTER;MIPMAPPING;_DEBUG;TOMB4_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>../tomb4/pch.h</PrecompiledHeaderFile>


### PR DESCRIPTION
Added an additional compiler define `MIPMAPPING`.
For Room Textures, mipmap count is set to 2
For Object Textures, mipmap count is set to 1
Having more mipmaps causes too severe texture bleeding issues.